### PR TITLE
Handle corner to corner problem attempt 1

### DIFF
--- a/nuvox_algorithm/tests/test_trace_algorithm/test_utils/test_corner_to_corner_handler.py
+++ b/nuvox_algorithm/tests/test_trace_algorithm/test_utils/test_corner_to_corner_handler.py
@@ -1,0 +1,14 @@
+import pytest
+
+from nuvox_algorithm.trace_algorithm.utils import get_corner_to_corner_variants
+
+
+@pytest.mark.parametrize(
+    'kis, expected_variants', [
+        ('167', ['167']),  # contains not corner-to-corner
+        ('13', ['13', '123']),
+        ('139', ['139', '1369', '1239', '12369'])
+    ]
+)
+def test_get_corner_to_corner_variants(kis, expected_variants):
+    assert get_corner_to_corner_variants(kis) == expected_variants

--- a/nuvox_algorithm/trace_algorithm/trace_algorithm.py
+++ b/nuvox_algorithm/trace_algorithm/trace_algorithm.py
@@ -76,12 +76,13 @@ class TraceAlgorithm:
                 predicted_kis=kis
             )
 
-        # For transitions from a corner key to another corner
-        # key (excluding diagonals) e.g (1-->3, 7-->9 etc.) we
-        # cannot detect from turning points alone whether the
+        # For transitions from a corner key to an opposite corner
+        # key (excluding diagonals) (e.g. 1-->3) we cannot
+        # detect from turning points alone whether the
         # key in between was intended or not. For now we handle
         # this by assigning equal probability to the KIS where
-        # the middle key is/isn't added.
+        # the middle key is/isn't added. Read docstring of
+        # 'get_corner_to_corner_variants' for further explanation.
         corner_to_corner_variants = get_corner_to_corner_variants(kis)
         prob = 1 / len(corner_to_corner_variants)
 

--- a/nuvox_algorithm/trace_algorithm/trace_algorithm.py
+++ b/nuvox_algorithm/trace_algorithm/trace_algorithm.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from nuvox_algorithm.core import nuvox_keyboard, TracePoint
 from nuvox_algorithm.utils.list_funcs import filter_adjacent_duplicates
-from nuvox_algorithm.trace_algorithm.utils import rdp, angle
+from nuvox_algorithm.trace_algorithm.utils import rdp, angle, get_corner_to_corner_variants
 
 
 class TraceAlgorithm:
@@ -68,10 +68,6 @@ class TraceAlgorithm:
         # Convert list to string i.e. [1, 2, 3] --> '123' (lists cannot be keys of a dictionary)
         kis = ''.join(key_ids)
 
-        kis_to_predicted_probability = {
-            kis: 1.0
-        }
-
         if plot:
             self.plot_prediction(
                 points=points,
@@ -79,6 +75,20 @@ class TraceAlgorithm:
                 turning_point_indices=turning_point_indices,
                 predicted_kis=kis
             )
+
+        # For transitions from a corner key to another corner
+        # key (excluding diagonals) e.g (1-->3, 7-->9 etc.) we
+        # cannot detect from turning points alone whether the
+        # key in between was intended or not. For now we handle
+        # this by assigning equal probability to the KIS where
+        # the middle key is/isn't added.
+        corner_to_corner_variants = get_corner_to_corner_variants(kis)
+        prob = 1 / len(corner_to_corner_variants)
+
+        kis_to_predicted_probability = {
+            _kis: prob for _kis in corner_to_corner_variants
+        }
+
 
         return kis_to_predicted_probability
 

--- a/nuvox_algorithm/trace_algorithm/utils/__init__.py
+++ b/nuvox_algorithm/trace_algorithm/utils/__init__.py
@@ -2,3 +2,5 @@ from .download_dataset import download_trace_algorithm_train_set, download_trace
 from .load_dataset import load_train_set, load_test_set
 from .rdp import rdp
 from .angle import angle
+from .corner_to_corner_handler import get_corner_to_corner_variants
+

--- a/nuvox_algorithm/trace_algorithm/utils/corner_to_corner_handler.py
+++ b/nuvox_algorithm/trace_algorithm/utils/corner_to_corner_handler.py
@@ -2,6 +2,10 @@ from typing import Optional
 
 from nuvox_algorithm.utils.list_funcs import sequential_pairs
 
+# A dictionary mapping a corner-corner key ID pair
+# to the ID of the key that is in the middle of
+# those corner keys. For example '13': '2' means
+# key 2 is between keys 1 and 3.
 corner_corner_to_middle = {
     '13': '2',
     '31': '2',
@@ -15,6 +19,31 @@ corner_corner_to_middle = {
 
 
 def get_corner_to_corner_variants(kis, n: Optional[int] = 0):
+    """This function is used to make up for the fact that by
+    solely using turning points in the path to determine which
+    keys were intended, you cannot know whether or not the user
+    intended the middle key when the transition from one corner
+    key to an opposite (non-diagonal) corner key. For example,
+    if we detect turning points at key '1' followed by a straight
+    line to key '3' - we cannot know whether the user also intended
+    key '2' in the middle.
+
+    This function takes a KIS (e.g. '13') and returns a list containing
+    all variations of that KIS where for each corner-to-corner transition
+    there is one variant that does and one that does not include the middle
+    key between them.
+
+    Notes
+    --------
+    - The function is called recursively.
+
+    Examples
+    ---------
+    - '167' --> ['167'] - no variations because '167' contains no transitions
+    from one corner to an opposite corner.
+    - '13' --> ['13', '123'] - contains the two variations where middle key 2
+    is/isn't present.
+    """
     c = 0
     for idx, (k1, k2) in enumerate(sequential_pairs(kis)):
         middle_key = corner_corner_to_middle.get(f'{k1}{k2}')
@@ -25,8 +54,3 @@ def get_corner_to_corner_variants(kis, n: Optional[int] = 0):
             else:
                 c += 1
     return [kis]
-
-
-if __name__ == '__main__':
-    a = get_corner_to_corner_variants('139')
-    print(a)

--- a/nuvox_algorithm/trace_algorithm/utils/corner_to_corner_handler.py
+++ b/nuvox_algorithm/trace_algorithm/utils/corner_to_corner_handler.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+from nuvox_algorithm.utils.list_funcs import sequential_pairs
+
+corner_corner_to_middle = {
+    '13': '2',
+    '31': '2',
+    '17': '4',
+    '71': '4',
+    '39': '6',
+    '93': '6',
+    '79': '8',
+    '97': '8'
+}
+
+
+def get_corner_to_corner_variants(kis, n: Optional[int] = 0):
+    c = 0
+    for idx, (k1, k2) in enumerate(sequential_pairs(kis)):
+        middle_key = corner_corner_to_middle.get(f'{k1}{k2}')
+        if middle_key is not None:
+            if c == n:
+                kis_with_middle_key = f'{kis[:idx + 1]}{middle_key}{kis[idx + 1:]}'
+                return [*get_corner_to_corner_variants(kis, n + 1), *get_corner_to_corner_variants(kis_with_middle_key, n)]
+            else:
+                c += 1
+    return [kis]
+
+
+if __name__ == '__main__':
+    a = get_corner_to_corner_variants('139')
+    print(a)


### PR DESCRIPTION
- Added function `get_corner_to_corner_variants` which returns all variations of a KIS whereby for each corner-to-corner transition there exists a variant where the middle key is/isn't present. E.g. `'13' --> ['13', '123']`
- Using this function in trace algorithm.
- Improves top 3 acc from 92.07 to 93.89 on train set